### PR TITLE
안준영 문제풀이 10

### DIFF
--- a/junyeong/src/boj2566/Main.java
+++ b/junyeong/src/boj2566/Main.java
@@ -1,0 +1,32 @@
+package boj2566;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int max = -1;
+        int row = -1;
+        int col = -1;
+
+        for (int i = 1; i <= 9; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            for (int j = 1; j <= 9; j++) {
+                int num = Integer.parseInt(st.nextToken());
+
+                if (num > max) {
+                    max = num;
+                    row = i;
+                    col = j;
+                }
+            }
+        }
+
+        System.out.println(max);
+        System.out.println(row + " " + col);
+    }
+}


### PR DESCRIPTION
## 문제

[2566 최댓값](https://www.acmicpc.net/problem/2566)

<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명

### 풀이 도출 과정
9×9 행렬(81개 수)을 입력받는다.

최댓값을 찾고, 그 값이 위치한 행 번호와 열 번호를 출력한다.

(행/열 번호는 1부터 시작)

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

- 시간복잡도: O(1)

<!-- 위와 같이 복잡도를 산정하게 된 이유 -->
81개의 수만 비교하므로 상수시간이다.

## 채점 결과

<!-- 문제 푼 결과 캡처 -->
<img width="1195" height="107" alt="image" src="https://github.com/user-attachments/assets/9d4001b9-097c-4d10-b767-e48aa2ef037e" />

