### PR TITLE
박종범 문제풀이 15

### DIFF
--- a/jongbum/2161/2161.cpp
+++ b/jongbum/2161/2161.cpp
@@ -1,0 +1,27 @@
+#include <iostream>
+#include <queue>
+
+using namespace std;
+
+int main() {
+    ios_base::sync_with_stdio(false);
+    cin.tie(NULL);
+
+    int n;
+    cin >> n;
+
+    queue<int> q;
+
+    for (int i = 1; i <= n; i++) q.push(i);
+
+    while (!q.empty()) {
+        cout << q.front() << ' ';
+        q.pop();
+
+        if (q.empty()) break;
+
+        q.push(q.front());
+        q.pop();
+    }
+    return 0;
+}


### PR DESCRIPTION
## 문제
[2161 카드1](https://www.acmicpc.net/problem/2161)

## 풀이

### 풀이에 대한 직관적인 설명
1. 큐에 1부터 N까지의 수를 넣습니다.
2. 큐의 front를 출력하고 그 수를 삭제합니다.
3. 큐의 front를 다시 큐에 삽입하고 그 수를 삭제합니다.

위 과정을 큐가 빌 때까지 반복합니다.

### 풀이 도출 과정
1. N장의 카드는 결국 FIFO 형태기 때문에 큐를 사용했습니다.
2. 제일 위의 카드를 버린다는 건 결국 큐에서 pop을 의미합니다.
3. 제일 위의 카드를 제일 밑으로 옮긴다는 건 큐의 front를 큐에 삽입한 후 pop한다는 걸 의미합니다.
4. 이를 통해 큐가 가진 기능들을 활용해 문제를 풀었습니다.

## 복잡도

* 시간복잡도 : O(N)

    * 연산 과정이 N에 비례하기 때문에 `O(N)`

    * 따라서 시간복잡도는 `O(N)` 입니다.

## 채점 결과
<img width="1431" height="50" alt="2161" src="https://github.com/user-attachments/assets/3c16feef-24ed-4548-822d-6c153c866131" />

### 사용한 언어
C++

### 사용한 소스코드
```
#include <iostream>
#include <queue>

using namespace std;

int main() {
    ios_base::sync_with_stdio(false);
    cin.tie(NULL);

    int n;
    cin >> n;

    queue<int> q;

    for (int i = 1; i <= n; i++) q.push(i);

    while (!q.empty()) {
        cout << q.front() << ' ';
        q.pop();

        if (q.empty()) break;

        q.push(q.front());
        q.pop();
    }
    return 0;
}
```