### PR TITLE
프로그래머스 알고리즘 문제 풀이 - 스택/큐 42587

### DIFF
--- a/daun/Solution_42587.java
+++ b/daun/Solution_42587.java
@@ -1,0 +1,41 @@
+package daun;
+
+import java.util.*;
+
+class Solution_42587 {
+    public int solution(int[] priorities, int location) {
+
+        // 큐에 우선순위와 인덱스를 저장
+        Deque<int[]> q = new ArrayDeque<>();
+        for(int i = 0; i < priorities.length; i++){
+            q.offerLast(new int[]{priorities[i], i});
+        }
+
+        int printed = 0; // 지금까지 실행된 프로세스 수
+        while(!q.isEmpty()){
+            // 큐의 맨 앞 프로세스 꺼내기
+            int[] cur = q.pollFirst();
+            int p = cur[0];
+            int index = cur[1];
+
+            // 지금 꺼낸 프로세스보다 높은 우선순위가 있는지 확인
+            boolean hasHigher = false;
+            for(int[] e : q){ // 큐 전체 탐색
+                if(e[0] > p){ // 더 높은 우선순위가 있으면
+                    hasHigher = true;
+                    break;
+                }
+            }
+            if(hasHigher){
+                // 다시 큐에 뒤로 넣음
+                q.offerLast(cur);
+            } else {
+                printed++;
+                if(index == location){
+                    return printed;
+                }
+            }
+        }
+        return -1;
+    }
+}


### PR DESCRIPTION
## 문제

[42587 프로세스](https://school.programmers.co.kr/learn/courses/30/lessons/42587)

## 풀이

### 풀이에 대한 직관적인 설명
1. 큐에 우선순위와 인덱스 저장
2. 큐의 맨 앞 프로세스 꺼내기
3. 꺼낸 프로세스보다 높은 우선순위가 있는지 확인
4. 있으면 다시 큐 뒤에 넣고
5. 없으면 출력

### 공부 내용
offerLast : 뒤쪽에 원소 삽입 (큐의 enqueue와 같음)
pollFirst : 앞쪽에서 원소 꺼내고 제거 (큐의 dequeue와 같음)

## 복잡도

- 시간복잡도
O(n^2)

## 채점 결과
<img width="833" height="264" alt="image" src="https://github.com/user-attachments/assets/fa2c14cf-236c-4432-8999-5dcc72971dd5" />