### PR TITLE
김수정 문제풀이 19

### DIFF
--- a/sujeong/BOJ10867/Main.java
+++ b/sujeong/BOJ10867/Main.java
@@ -1,0 +1,25 @@
+package BOJ10867;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.TreeSet;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        TreeSet<Integer> set = new TreeSet<>();
+
+        int N = Integer.parseInt(br.readLine());
+
+        String[] str = br.readLine().split(" ");
+
+        for (int i = 0; i < N; i++) {
+            set.add(Integer.parseInt(str[i]));
+        }
+
+        for (Integer integer : set) {
+            System.out.print(integer + " ");
+        }
+    }
+}


### PR DESCRIPTION
## 문제

[10867 중복 빼고 정렬하기](https://www.acmicpc.net/problem/10867)

<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명
주어진 숫자들을 중복 없이 오름차순으로 정렬하는 문제

### 풀이 도출 과정
TreeSet은 레드-블랙 트리(Red-Black Tree)를 사용하여 데이터를 저장하기 때문에 삽입 시 자동으로 오름차순 정렬됨. 또한 Set의 특성상 중복된 값은 저장되지 않음
- set.add() : Treeset에 값 추가

<for-each문>
for (Integer integer : set) { ... }을 통해 set에 들어있는 정수들을 꺼낸 뒤 출력.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

- 시간복잡도 : O(N logN)

<!-- 위와 같이 복잡도를 산정하게 된 이유 -->
N개의 정수를 TreeSet에 추가하는 과정은 O(log N), 정렬된 결과를 출력하는 과정은 O(N)이므로 O(N logN)

## 채점 결과

<!-- 문제 푼 결과 캡처 -->
<img width="1279" height="36" alt="스크린샷 2025-09-29 214416" src="https://github.com/user-attachments/assets/b28d1bcd-0d61-41e9-99bc-e31784414f06" />
