### PR TITLE
이아림 문제풀이 15

### DIFF
--- a/arim/src/5568.py
+++ b/arim/src/5568.py
@@ -1,0 +1,13 @@
+import sys
+from itertools import permutations
+
+n = int(sys.stdin.readline())
+k = int(sys.stdin.readline())
+cards = [sys.stdin.readline().strip() for _ in range(n)]
+
+results = set()
+
+for p in permutations(cards, k):
+    results.add(''.join(p))
+
+print(len(results))


### PR DESCRIPTION
## 문제

[5568 카드 놓기](https://www.acmicpc.net/problem/5568)

<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명
- n장의 카드 중 k개를 뽑아 만들 수 있는 모든 순서를 생성한다.
- 겹치는 수를 제외한 뒤 숫자를 세 출력한다.
- ex) n : 3, k : 2 일때, 3장의 카드 번호는 각각 1,12,2라면 총 112, 121,12, 21, 122, 221 총 6개가 나와야한다.

### 풀이 도출 과정
- itertools.permutations 라이브러리를 사용해 모든 순열을 구한다.
- 생성된 각 순열을 하나의 문자열로 합친 뒤 set에 저장한다.
- set의 갯수를 출력한다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

- 시간복잡도 : O(nPk)

<!-- 위와 같이 복잡도를 산정하게 된 이유 -->
- n장중 k개를 골라서 순열을 구해야하기 때문이다.

## 채점 결과

<!-- 문제 푼 결과 캡처 -->
<img width="1432" height="97" alt="image" src="https://github.com/user-attachments/assets/6e7c32ee-d337-49df-88e8-bbd6bd3dea5e" />
